### PR TITLE
Add a mybinder.org config and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Jupyter Tldraw
 [![PyPI version](https://img.shields.io/pypi/v/tldraw.svg)](https://pypi.org/project/tldraw/)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/kolibril13/jupyter-tldraw/HEAD)
+
 <img width="946" alt="image" src="https://github.com/kolibril13/jupyter-tldraw/assets/44469195/8ba7e662-1f35-4e3b-b342-6d9fd3079e22">
 
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -6,3 +6,5 @@ dependencies:
   - numpy
   - pip
   - polars
+  - pip:
+    - quak

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,8 @@
+name: tldraw-demos
+channels:
+  - conda-forge
+dependencies:
+  - matplotlib
+  - numpy
+  - pip
+  - polars

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+pip install .


### PR DESCRIPTION
This allows this repo to be launched on mybinder.org, so it's easy to try:
https://mybinder.org/v2/gh/manics/jupyter-tldraw/mybinder