### PR TITLE
Add autosave feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Three example notebooks are included:
 
 | Notebook | Widget | What it shows |
 | --- | --- | --- |
-| [`basic.ipynb`](basic.ipynb) | `TldrawWidget` | A plain tldraw canvas embedded in a cell. |
+| [`basic.ipynb`](basic.ipynb) | `TldrawWidget` | A plain tldraw canvas embedded in a cell. Supports optional autosave via `path=`. |
 | [`monkey.ipynb`](monkey.ipynb) | `MonkeyWidget` | A 🐒 emoji on the canvas; its `x` / `y` are synced as traitlets, so you can `.observe(...)` the position from Python. |
 | [`stroke.ipynb`](stroke.ipynb) | `StrokeWidget` | Captures the currently-drawn freehand stroke as a `[[x, y], ...]` list in Python via the `stroke` traitlet. |
 
@@ -27,6 +27,10 @@ Minimal usage:
 ```python
 from tldraw import TldrawWidget
 t = TldrawWidget()
+t
+
+# load and save to ./drawing.tldr on your disk
+t = TldrawWidget(path="drawing.tldr")
 t
 ```
 

--- a/basic.ipynb
+++ b/basic.ipynb
@@ -2,31 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "98232e9e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "be043273f95e4e898fd9a4b43395ca70",
-       "version_major": 2,
-       "version_minor": 1
-      },
-      "text/plain": [
-       "<tldraw.TldrawWidget object at 0x10d077620>"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from tldraw import TldrawWidget\n",
-    "t = TldrawWidget(width=900, height=440)\n",
-    "t"
-   ]
+   "outputs": [],
+   "source": "from tldraw import TldrawWidget\n\n# plain canvas\nt = TldrawWidget(width=900, height=440)\nt"
   },
   {
    "cell_type": "code",
@@ -34,7 +14,7 @@
    "id": "2d91b76e-3a85-42cf-82ff-86d3633b0bcb",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": "# load and save to ./drawing.tldr on your disk\nt = TldrawWidget(path=\"drawing.tldr\", width=900, height=440)\nt"
   }
  ],
  "metadata": {

--- a/js/basic.jsx
+++ b/js/basic.jsx
@@ -4,18 +4,34 @@ import { Tldraw } from "@tldraw/tldraw";
 import "@tldraw/tldraw/tldraw.css";
 import "./widget.css";
 
+const LICENSE_KEY = "tldraw-2026-07-31/WyJQUVo1VG1jbCIsWyIqIl0sMTYsIjIwMjYtMDctMzEiXQ.CkPyjP0F73725rI7q6mqJHPO1raBBtGrGMD4brtu2PaIXIywy8PRtij6fcPZHLws627nS5OuHc2OPquvffbhog";
+
 const render = createRender(() => {
   const [width] = useModelState("width");
   const [height] = useModelState("height");
+  const [snapshot, setSnapshot] = useModelState("snapshot");
+
+  const handleMount = (editor) => {
+    if (snapshot) {
+      try {
+        editor.loadSnapshot(JSON.parse(snapshot));
+      } catch (e) {
+        console.warn("tldraw: failed to load snapshot", e);
+      }
+    }
+
+    let saveTimer = null;
+    editor.store.listen(() => {
+      clearTimeout(saveTimer);
+      saveTimer = setTimeout(() => {
+        setSnapshot(JSON.stringify(editor.getSnapshot()));
+      }, 1000);
+    });
+  };
+
   return (
-    <div
-      style={{
-        position: "relative",
-        width: width,
-        height: height,
-      }}
-    >
-      <Tldraw autoFocus={false} licenseKey="tldraw-2026-07-31/WyJQUVo1VG1jbCIsWyIqIl0sMTYsIjIwMjYtMDctMzEiXQ.CkPyjP0F73725rI7q6mqJHPO1raBBtGrGMD4brtu2PaIXIywy8PRtij6fcPZHLws627nS5OuHc2OPquvffbhog" />
+    <div style={{ position: "relative", width, height }}>
+      <Tldraw autoFocus={false} onMount={handleMount} licenseKey={LICENSE_KEY} />
     </div>
   );
 });

--- a/src/tldraw/__init__.py
+++ b/src/tldraw/__init__.py
@@ -1,7 +1,8 @@
 import importlib.metadata
 import pathlib
 import anywidget
-from traitlets import Int, Float, List
+from traitlets import Int, Float, List, Unicode
+from traitlets import observe
 
 try:
     __version__ = importlib.metadata.version("tldraw")
@@ -14,9 +15,21 @@ _STATIC = pathlib.Path(__file__).parent / "static"
 class TldrawWidget(anywidget.AnyWidget):
     width = Int(600).tag(sync=True)
     height = Int(300).tag(sync=True)
+    snapshot = Unicode("").tag(sync=True)
 
     _esm = _STATIC / "basic.js"
     _css = _STATIC / "basic.css"
+
+    def __init__(self, path: pathlib.Path | str | None = None):
+        super().__init__()
+        self._path = pathlib.Path(path) if path is not None else None
+        if self._path is not None and self._path.exists():
+            self.snapshot = self._path.read_text()
+
+    @observe("snapshot")
+    def _on_snapshot_change(self, change):
+        if self._path is not None and change["new"]:
+            self._path.write_text(change["new"])
 
 
 class MonkeyWidget(anywidget.AnyWidget):


### PR DESCRIPTION
This should fix #5 

<img width="1132" height="638" alt="image" src="https://github.com/user-attachments/assets/266c5341-f6ab-4c2d-a71d-8fdcdb253055" />


I think it's a lot cleaner than trying to save the jupyter state: just use the tldraw API to save to json.

Usage:
```
TldrawWidget(path="./path/to/saved_drawing.tldr")
```

I updated README and notebooks.


Hope it helps !

Note: the only thing it does not store is zoom level.